### PR TITLE
Change operator-linebreak rule to match styleguide

### DIFF
--- a/javascript/packages/eslint-config-nebenan-base/index.js
+++ b/javascript/packages/eslint-config-nebenan-base/index.js
@@ -41,10 +41,8 @@ module.exports = {
     'function-paren-newline': 'off', // forces to write illegible code
     'prefer-destructuring': 'off', // forces to write broken code!
     'no-control-regex': 'off',
-    'operator-linebreak': ['error', 'after'], // better readability
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     'prefer-promise-reject-errors': 'off',
-
     'import/no-dynamic-require': 'off',
     'import/extensions': ['error', 'never'],
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],

--- a/javascript/packages/eslint-config-nebenan-base/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan-base",
-  "version": "1.1.0",
+  "version": "1.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/javascript/packages/eslint-config-nebenan-base/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan-base",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/javascript/packages/eslint-config-nebenan-base/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan-base",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/javascript/packages/eslint-config-nebenan-base/package.json
+++ b/javascript/packages/eslint-config-nebenan-base/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "linter",
     "config",

--- a/javascript/packages/eslint-config-nebenan-base/package.json
+++ b/javascript/packages/eslint-config-nebenan-base/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "keywords": [
     "linter",
     "config",

--- a/javascript/packages/eslint-config-nebenan-base/package.json
+++ b/javascript/packages/eslint-config-nebenan-base/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0",
   "keywords": [
     "linter",
     "config",

--- a/javascript/packages/eslint-config-nebenan-base/test/valid/misc.es
+++ b/javascript/packages/eslint-config-nebenan-base/test/valid/misc.es
@@ -50,14 +50,14 @@ if (condition > true) {
 const sum = 5 + 5;
 
 const longCode = (
-  condition > 5 &&
-  condition === true &&
-  condition < 3 &&
-  condition > 5 &&
-  condition > 5 &&
-  condition > 5 &&
-  condition > 5 &&
   condition > 5
+  && condition === true
+  && condition < 3
+  && condition > 5
+  && condition > 5
+  && condition > 5
+  && condition > 5
+  && condition > 5
 );
 
 const comma = [1, 2];

--- a/javascript/packages/eslint-config-nebenan/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -442,9 +442,9 @@
       }
     },
     "eslint-config-nebenan-base": {
-      "version": "1.3.0-beta.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.3.0-beta.0.tgz",
-      "integrity": "sha512-lhcYyDTgQZ3Jw4PG0Mn4H3ZbtZoZyqKkEvCcFo/jfDCdaUiMRaStYwFwO6lmthOo5DdIXK7t6WUiQpv//PHYwQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.3.0.tgz",
+      "integrity": "sha512-ul/A3yN6o72NCiPoh2+vdrQmm6SwvCidgAgDL7RnyxsgeYPJpPj1G+JO79Ye8oeoIdrb889xn8CGbFdCQw6eiA==",
       "requires": {
         "eslint-config-airbnb-base": "^14.1.0",
         "eslint-plugin-import": "^2.20.1"

--- a/javascript/packages/eslint-config-nebenan/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -442,12 +442,12 @@
       }
     },
     "eslint-config-nebenan-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.1.0.tgz",
-      "integrity": "sha512-IBHf6lxXMzTEQWF+hkspQZIam1AOW4jmKQPJzPaOwelNtpqVCSaU2ZlZ/78BPbeaOQ0avHz8YaDxUKISbPZdLw==",
+      "version": "1.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.3.0-beta.0.tgz",
+      "integrity": "sha512-lhcYyDTgQZ3Jw4PG0Mn4H3ZbtZoZyqKkEvCcFo/jfDCdaUiMRaStYwFwO6lmthOo5DdIXK7t6WUiQpv//PHYwQ==",
       "requires": {
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-plugin-import": "^2.17.1"
+        "eslint-config-airbnb-base": "^14.1.0",
+        "eslint-plugin-import": "^2.20.1"
       }
     },
     "eslint-import-resolver-node": {

--- a/javascript/packages/eslint-config-nebenan/package-lock.json
+++ b/javascript/packages/eslint-config-nebenan/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nebenan",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -442,9 +442,9 @@
       }
     },
     "eslint-config-nebenan-base": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.3.0.tgz",
-      "integrity": "sha512-ul/A3yN6o72NCiPoh2+vdrQmm6SwvCidgAgDL7RnyxsgeYPJpPj1G+JO79Ye8oeoIdrb889xn8CGbFdCQw6eiA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-nebenan-base/-/eslint-config-nebenan-base-1.3.1.tgz",
+      "integrity": "sha512-KpfGBGWO4n36fuGOU+8rdU9Pf9pLi/YEzAShqQfeJ9zXwC/X8PTflfVRyFG356b/3irnP4gunAbAqr1uSGsL5g==",
       "requires": {
         "eslint-config-airbnb-base": "^14.1.0",
         "eslint-plugin-import": "^2.20.1"

--- a/javascript/packages/eslint-config-nebenan/package.json
+++ b/javascript/packages/eslint-config-nebenan/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "linter",
     "config",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-nebenan-base": "^1.3.0",
+    "eslint-config-nebenan-base": "^1.3.1",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.19.0",

--- a/javascript/packages/eslint-config-nebenan/package.json
+++ b/javascript/packages/eslint-config-nebenan/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "keywords": [
     "linter",
     "config",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-nebenan-base": "^1.1.0",
+    "eslint-config-nebenan-base": "^1.3.0-beta.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.19.0",

--- a/javascript/packages/eslint-config-nebenan/package.json
+++ b/javascript/packages/eslint-config-nebenan/package.json
@@ -6,7 +6,7 @@
   "readmeFilename": "README.md",
   "repository": "goodhood-eu/styleguide",
   "bugs": "https://github.com/goodhood-eu/styleguide/issues",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0",
   "keywords": [
     "linter",
     "config",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-nebenan-base": "^1.3.0-beta.0",
+    "eslint-config-nebenan-base": "^1.3.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.19.0",


### PR DESCRIPTION
Airbnb styleguide says to put "conditional operators" before the condition (like our styleguide), therefore the default values from their configuration already provides that rule.

Eslint autocorrect should help us with updating packages depending on eslint-config-nebenan. I assume this rule change will cause lots linting errors.